### PR TITLE
feat: add isekai idol fanvote microsite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# codex-test
+# isekai-idol-fanvote-prelim-1st
+
+이 프로젝트는 “이세계아이돌 팬 투표 예선 1위”를 기념하고 본선 참여를 안내하는 팬 메이킹 마이크로 사이트입니다.
+
+## 로컬 개발
+
+```bash
+npm install
+npm run dev
+```
+
+## 배포
+
+GitHub Pages에 자동 배포되도록 설정되어 있습니다. `main` 브랜치에 푸시하면 GitHub Actions가 빌드 후 `gh-pages`에 배포합니다.
+
+사이트는 다음 주소에서 확인할 수 있습니다.
+
+```
+https://<username>.github.io/isekai-idol-fanvote-prelim-1st/
+```
+
+## 라이선스
+
+비공식 팬 프로젝트입니다.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>팬 투표 예선 1위! 🎉 이세계아이돌</title>
+    <meta name="description" content="여러분의 한 표가 만든 결과, 본선까지 함께 가요." />
+    <meta property="og:title" content="팬 투표 예선 1위! 🎉 이세계아이돌" />
+    <meta property="og:description" content="여러분의 한 표가 만든 결과, 본선까지 함께 가요." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://example.com/isekai-idol-fanvote-prelim-1st/" />
+    <meta property="og:image" content="https://via.placeholder.com/1200x630.png?text=OG+Image" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="팬 투표 예선 1위! 🎉 이세계아이돌" />
+    <meta name="twitter:description" content="여러분의 한 표가 만든 결과, 본선까지 함께 가요." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "isekai-idol-fanvote-prelim-1st",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "canvas-confetti": "^1.9.3",
+    "react-icons": "^5.0.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="50" fill="#a855f7"/></svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Hero from './components/Hero';
+import Metrics from './components/Metrics';
+import Timeline from './components/Timeline';
+import VoteGuide from './components/VoteGuide';
+import Gallery from './components/Gallery';
+import FanBook from './components/FanBook';
+import Footer from './components/Footer';
+
+export default function App() {
+  const navItems = [
+    { href: '#metrics', label: '지표' },
+    { href: '#timeline', label: '타임라인' },
+    { href: '#vote-guide', label: '투표 가이드' },
+    { href: '#gallery', label: '갤러리' },
+    { href: '#fanbook', label: '메시지 북' },
+  ];
+  return (
+    <div>
+      <nav className="fixed top-0 inset-x-0 bg-white shadow z-10">
+        <ul className="flex justify-center gap-4 p-4">
+          {navItems.map((n) => (
+            <li key={n.href}><a href={n.href} className="text-primary hover:underline">{n.label}</a></li>
+          ))}
+        </ul>
+      </nav>
+      <main className="pt-16">
+        <Hero />
+        <Metrics />
+        <section id="why" className="py-12">
+          <h2 className="text-center text-2xl font-bold mb-8">왜 예선 1위가 중요할까</h2>
+          <ul className="max-w-3xl mx-auto list-disc list-inside space-y-2">
+            <li>본선 가산점</li>
+            <li>주목도 상승</li>
+            <li>팬덤 결집</li>
+          </ul>
+        </section>
+        <Timeline />
+        <VoteGuide />
+        <Gallery />
+        <FanBook />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type Props = React.PropsWithChildren<{
+  href?: string;
+  onClick?: () => void;
+  target?: string;
+  rel?: string;
+  className?: string;
+}>;
+
+export default function Button({ href, children, onClick, target, rel, className }: Props) {
+  const base = 'px-4 py-2 rounded bg-primary text-white hover:bg-secondary transition-colors';
+  if (href) {
+    return (
+      <a href={href} onClick={onClick} target={target} rel={rel} className={`${base} ${className || ''}`.trim()}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <button onClick={onClick} className={`${base} ${className || ''}`.trim()}>
+      {children}
+    </button>
+  );
+}

--- a/src/components/FanBook.tsx
+++ b/src/components/FanBook.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+
+type Entry = { name: string; message: string };
+
+const sanitize = (s: string) => s.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+export default function FanBook() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('fanbook');
+    if (saved) setEntries(JSON.parse(saved));
+  }, []);
+
+  const add = () => {
+    if (!name || !message) return;
+    const entry = { name: sanitize(name), message: sanitize(message) };
+    const newEntries = [entry, ...entries];
+    setEntries(newEntries);
+    localStorage.setItem('fanbook', JSON.stringify(newEntries));
+    setName('');
+    setMessage('');
+  };
+
+  return (
+    <section className="py-12 bg-gray-100" id="fanbook">
+      <h2 className="text-center text-2xl font-bold mb-8">팬 메시지 북</h2>
+      <div className="max-w-xl mx-auto space-y-4">
+        <input
+          aria-label="이름"
+          className="w-full border p-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="이름"
+        />
+        <textarea
+          aria-label="메시지"
+          className="w-full border p-2"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="메시지"
+        />
+        <button onClick={add} className="px-4 py-2 bg-primary text-white rounded">남기기</button>
+        <ul className="space-y-2">
+          {entries.map((e, i) => (
+            <li key={i} className="bg-white p-2 rounded shadow">
+              <strong>{e.name}</strong>
+              <p>{e.message}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { FaTwitter, FaYoutube, FaInstagram } from 'react-icons/fa';
+
+export default function Footer() {
+  return (
+    <footer className="bg-gray-800 text-white text-center py-8" id="footer">
+      <p className="mb-2">비공식 팬 페이지</p>
+      <p className="mb-4">제작자: 팬</p>
+      <div className="flex justify-center gap-4 text-2xl">
+        <a href="#" aria-label="Twitter"><FaTwitter /></a>
+        <a href="#" aria-label="YouTube"><FaYoutube /></a>
+        <a href="#" aria-label="Instagram"><FaInstagram /></a>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+const images = Array.from({ length: 6 }).map((_, i) => `https://via.placeholder.com/300?text=Image+${i + 1}`);
+
+export default function Gallery() {
+  const [open, setOpen] = useState<string | null>(null);
+  return (
+    <section className="py-12" id="gallery">
+      <h2 className="text-center text-2xl font-bold mb-8">갤러리</h2>
+      <div className="max-w-4xl mx-auto grid grid-cols-2 md:grid-cols-3 gap-4">
+        {images.map((src, i) => (
+          <img key={i} src={src} alt={`갤러리 이미지 ${i + 1}`} className="cursor-pointer" onClick={() => setOpen(src)} />
+        ))}
+      </div>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center"
+          onClick={() => setOpen(null)}
+          role="dialog"
+          aria-modal="true"
+        >
+          <img src={open} alt="확대 이미지" className="max-h-full max-w-full" />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import confetti from 'canvas-confetti';
+import Button from './Button';
+
+export default function Hero() {
+  const prefersReduced = typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const [confettiOn, setConfettiOn] = useState(() => !prefersReduced && localStorage.getItem('confetti') !== 'off');
+
+  useEffect(() => {
+    if (confettiOn) {
+      confetti({ particleCount: 200, spread: 70, origin: { y: 0.6 } });
+    }
+  }, [confettiOn]);
+
+  const toggle = () => {
+    const next = !confettiOn;
+    setConfettiOn(next);
+    localStorage.setItem('confetti', next ? 'on' : 'off');
+  };
+
+  return (
+    <section className="bg-hero text-white text-center py-20" id="hero">
+      <h1 className="text-4xl font-bold mb-4">팬 투표 예선 1위! 🎉 이세계아이돌</h1>
+      <p className="mb-6">여러분의 한 표가 만든 결과, 본선까지 함께 가요.</p>
+      <div className="flex justify-center gap-4 mb-6">
+        <Button href="https://example.com/vote" target="_blank" rel="noopener">본선 투표 가이드</Button>
+        <Button href="https://example.com/notice" target="_blank" rel="noopener">공식 공지 보기</Button>
+        <Button href="https://example.com/community" target="_blank" rel="noopener">커뮤니티</Button>
+      </div>
+      <Button onClick={toggle} className="bg-white text-primary mt-4">{confettiOn ? '컨페티 끄기' : '컨페티 켜기'}</Button>
+    </section>
+  );
+}

--- a/src/components/Metrics.tsx
+++ b/src/components/Metrics.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function Metrics() {
+  const metrics = [
+    { label: '예선 득표수', value: '123,456' },
+    { label: '예선 종료일', value: '2024-05-01' },
+    { label: '본선 시작일', value: '2024-05-10' },
+  ];
+  return (
+    <section className="py-12 bg-gray-100" id="metrics">
+      <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-4 text-center">
+        {metrics.map((m) => (
+          <div key={m.label} className="p-4 bg-white rounded shadow">
+            <div className="text-sm text-gray-500">{m.label}</div>
+            <div className="text-2xl font-bold">{m.value}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function Timeline() {
+  const steps = [
+    '예선 시작',
+    '중간 집계',
+    '예선 1위 확정 🎉',
+    '본선 일정 안내',
+  ];
+  return (
+    <section className="py-12" id="timeline">
+      <h2 className="text-center text-2xl font-bold mb-8">타임라인</h2>
+      <div className="flex flex-col md:flex-row items-center justify-center gap-4">
+        {steps.map((s, i) => (
+          <React.Fragment key={s}>
+            <div className="p-4 bg-white rounded shadow text-center w-40">{s}</div>
+            {i < steps.length - 1 && <span className="hidden md:inline-block w-8 border-t-2 border-gray-300" aria-hidden="true"></span>}
+          </React.Fragment>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/VoteGuide.tsx
+++ b/src/components/VoteGuide.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function VoteGuide() {
+  const steps = ['회원가입', '인증', '투표'];
+  return (
+    <section className="py-12 bg-gray-100" id="vote-guide">
+      <h2 className="text-center text-2xl font-bold mb-8">본선 투표 가이드</h2>
+      <ol className="max-w-3xl mx-auto list-decimal list-inside space-y-2 mb-6">
+        {steps.map((s) => (
+          <li key={s}>{s}</li>
+        ))}
+      </ol>
+      <div className="max-w-md mx-auto mb-6">
+        <div className="w-full h-48 bg-gray-300 flex items-center justify-center">스크린샷</div>
+      </div>
+      <ul className="max-w-3xl mx-auto list-disc list-inside text-sm text-gray-600">
+        <li>중복 투표는 무효 처리됩니다.</li>
+        <li>시간대별 제한을 확인하세요.</li>
+      </ul>
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html { scroll-behavior: smooth; }
+
+:root {
+  font-family: 'Pretendard', 'Noto Sans KR', sans-serif;
+}
+
+:focus-visible {
+  @apply outline-none ring-2 ring-primary;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,20 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Pretendard', 'Noto Sans KR', ...defaultTheme.fontFamily.sans],
+      },
+      colors: {
+        primary: '#a855f7',
+        secondary: '#6b21a8',
+      },
+      backgroundImage: {
+        hero: 'linear-gradient(135deg,#a855f7,#6b21a8)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/isekai-idol-fanvote-prelim-1st/',
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- setup Vite + React + Tailwind project for 이세계아이돌 fan vote prelim celebration
- add hero, metrics, timeline, vote guide, gallery, fan message book, and footer components
- configure GitHub Pages deployment with workflow and base path

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm test`
- `npm run build` *(fails: vite: not found)*

Live URL: https://<username>.github.io/isekai-idol-fanvote-prelim-1st/


------
https://chatgpt.com/codex/tasks/task_e_68a3fb3367d4832183f3c32a7fe9766d